### PR TITLE
keymasterd: filter out trailing @.* from usernames by default.

### DIFF
--- a/cmd/keymasterd/app.go
+++ b/cmd/keymasterd/app.go
@@ -767,11 +767,14 @@ func (state *RuntimeState) reprocessUsername(username string) string {
 	if !state.Config.Base.DisableUsernameNormalization {
 		username = strings.ToLower(username)
 	}
-	filteredUsername := string(state.usernameFilterRE.ReplaceAll(
-		[]byte(username), nil))
-	logger.Debugf(1, "filtered user: \"%s\" to: \"%s\"\n",
-		username, filteredUsername)
-	return filteredUsername
+	if state.usernameFilterRE != nil {
+		filteredUsername := string(state.usernameFilterRE.ReplaceAll(
+			[]byte(username), nil))
+		logger.Debugf(1, "filtered user: \"%s\" to: \"%s\"\n",
+			username, filteredUsername)
+		username = filteredUsername
+	}
+	return username
 }
 
 const secretInjectorPath = "/admin/inject"

--- a/cmd/keymasterd/app.go
+++ b/cmd/keymasterd/app.go
@@ -153,7 +153,7 @@ type RuntimeState struct {
 	vipPushCookie        map[string]pushPollTransaction
 	localAuthData        map[string]localUserData
 	SignerIsReady        chan bool
-	usernameFilterRE     *regexp.Regexp
+	oktaUsernameFilterRE *regexp.Regexp
 	Mutex                sync.Mutex
 	pendingOauth2        map[string]pendingAuth2Request
 	storageRWMutex       sync.RWMutex
@@ -767,8 +767,8 @@ func (state *RuntimeState) reprocessUsername(username string) string {
 	if !state.Config.Base.DisableUsernameNormalization {
 		username = strings.ToLower(username)
 	}
-	if state.usernameFilterRE != nil {
-		filteredUsername := string(state.usernameFilterRE.ReplaceAll(
+	if state.oktaUsernameFilterRE != nil {
+		filteredUsername := string(state.oktaUsernameFilterRE.ReplaceAll(
 			[]byte(username), nil))
 		logger.Debugf(1, "filtered user: \"%s\" to: \"%s\"\n",
 			username, filteredUsername)

--- a/cmd/keymasterd/app_test.go
+++ b/cmd/keymasterd/app_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+)
+
+type oktaUsernameFilterTestType struct {
+	filter string
+	input  string
+	output string
+}
+
+var (
+	oktaUsernameFilterTests = []oktaUsernameFilterTestType{
+		{"", "user", "user"},
+		{"", "user@company.com", "user@company.com"},
+		{"", "user@company.com@blah", "user@company.com@blah"},
+		{defaultOktaUsernameFilterRegexp, "user", "user"},
+		{defaultOktaUsernameFilterRegexp, "user@company.com", "user"},
+		{defaultOktaUsernameFilterRegexp, "user@company.com@blah", "user"},
+	}
+)
+
+func TestOktaUsernameFilter(t *testing.T) {
+	state := &RuntimeState{}
+	for _, testCase := range oktaUsernameFilterTests {
+		state.oktaUsernameFilterRE = regexp.MustCompile(testCase.filter)
+		output := state.reprocessUsername(testCase.input)
+		if output != testCase.output {
+			t.Errorf(
+				"filter: \"%s\", input: \"%s\", output!=expected: \"%s\" != \"%s\"",
+				testCase.filter, testCase.input, output, testCase.output)
+		}
+	}
+}

--- a/cmd/keymasterd/config.go
+++ b/cmd/keymasterd/config.go
@@ -135,7 +135,7 @@ type AppConfigFile struct {
 const (
 	defaultRSAKeySize                  = 3072
 	defaultSecsBetweenDependencyChecks = 60
-	defaultUsernameFilterRegexp        = "@.*"
+	defaultOktaUsernameFilterRegexp    = "@.*"
 )
 
 func (state *RuntimeState) loadTemplates() (err error) {
@@ -394,9 +394,9 @@ func loadVerifyConfigFile(configFilename string) (*RuntimeState, error) {
 		logger.Debugf(1, "passwordChecker= %+v", runtimeState.passwordChecker)
 		usernameFilterRegexp := oktaConfig.UsernameFilterRegexp
 		if usernameFilterRegexp == "" {
-			usernameFilterRegexp = defaultUsernameFilterRegexp
+			usernameFilterRegexp = defaultOktaUsernameFilterRegexp
 		}
-		runtimeState.usernameFilterRE, err = regexp.Compile(
+		runtimeState.oktaUsernameFilterRE, err = regexp.Compile(
 			usernameFilterRegexp)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
As described in issue #4, when a user enters "username@company.com" rather
than "username" as their username, this typically leaves them in a limbo
state as the entered username is not typically listed in the U2F token
database. Solve this by stripping the `@` and everything after it.
Fixes #4 