### PR TITLE
Do not override built-in config location in keymaster.service.

### DIFF
--- a/misc/startup/keymaster.service
+++ b/misc/startup/keymaster.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 PermissionsStartOnly=true
-ExecStartPre=setcap cap_net_bind_service=+ep /usr/sbin/keymasterd
+ExecStartPre=/sbin/setcap cap_net_bind_service=+ep /usr/sbin/keymasterd
 ExecStart=/usr/sbin/keymasterd
 Restart=always
 RestartSec=20

--- a/misc/startup/keymaster.service
+++ b/misc/startup/keymaster.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 PermissionsStartOnly=true
 ExecStartPre=/usr/sbin/setcap cap_net_bind_service=+ep /usr/sbin/keymasterd
-ExecStart=/usr/sbin/keymasterd -config /etc/keymaster/server_config.yml
+ExecStart=/usr/sbin/keymasterd
 Restart=always
 RestartSec=20
 User=keymaster

--- a/misc/startup/keymaster.service
+++ b/misc/startup/keymaster.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 PermissionsStartOnly=true
-ExecStartPre=/usr/sbin/setcap cap_net_bind_service=+ep /usr/sbin/keymasterd
+ExecStartPre=setcap cap_net_bind_service=+ep /usr/sbin/keymasterd
 ExecStart=/usr/sbin/keymasterd
 Restart=always
 RestartSec=20

--- a/misc/startup/keymaster.service
+++ b/misc/startup/keymaster.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 PermissionsStartOnly=true
 ExecStartPre=/sbin/setcap cap_net_bind_service=+ep /usr/sbin/keymasterd
-ExecStart=/usr/sbin/keymasterd
+ExecStart=/usr/sbin/keymasterd -config /etc/keymaster/config.yml
 Restart=always
 RestartSec=20
 User=keymaster


### PR DESCRIPTION
Both the build-in default for the `-config` option and the output of `-generateConfig` have `/etc/keymaster/config.yml` as the configuration file. It's just confusing for the system service file to change that.