### PR TITLE
Add Okta UsernameSuffix configuration option to dis-ambiguate users.

### DIFF
--- a/cmd/keymasterd/config.go
+++ b/cmd/keymasterd/config.go
@@ -83,6 +83,7 @@ type OktaConfig struct {
 	Domain               string `yaml:"domain"`
 	Enable2FA            bool   `yaml:"enable_2fa"`
 	UsernameFilterRegexp string `yaml:"username_filter_regexp"`
+	UsernameSuffix       string `yaml:"username_suffix"`
 }
 
 type UserInfoLDAPSource struct {
@@ -425,7 +426,7 @@ func loadVerifyConfigFile(configFilename string,
 	}
 	if oktaConfig := runtimeState.Config.Okta; oktaConfig.Domain != "" {
 		runtimeState.passwordChecker, err = okta.NewPublic(oktaConfig.Domain,
-			logger)
+			oktaConfig.UsernameSuffix, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/authenticators/okta/impl.go
+++ b/lib/authenticators/okta/impl.go
@@ -61,18 +61,22 @@ type OktaApiPushResponseType struct {
 	Embedded        OktaApiEmbeddedDataResponseType `json:"_embedded,omitempty"`
 }
 
-func newPublicAuthenticator(oktaDomain string, logger log.DebugLogger) (
-	*PasswordAuthenticator, error) {
+func newPublicAuthenticator(oktaDomain string, usernameSuffix string,
+	logger log.DebugLogger) (*PasswordAuthenticator, error) {
 	return &PasswordAuthenticator{
-		authnURL:   fmt.Sprintf(authEndpointFormat, oktaDomain),
-		logger:     logger,
-		recentAuth: make(map[string]authCacheData),
+		authnURL:       fmt.Sprintf(authEndpointFormat, oktaDomain),
+		logger:         logger,
+		usernameSuffix: usernameSuffix,
+		recentAuth:     make(map[string]authCacheData),
 	}, nil
 }
 
 func (pa *PasswordAuthenticator) passwordAuthenticate(username string,
 	password []byte) (bool, error) {
-	loginData := OktaApiLoginDataType{Password: string(password), Username: username}
+	loginData := OktaApiLoginDataType{
+		Password: string(password),
+		Username: username + pa.usernameSuffix,
+	}
 	body := &bytes.Buffer{}
 	encoder := json.NewEncoder(body)
 	encoder.SetIndent("", "    ") // Make life easier for debugging.

--- a/lib/authenticators/okta/okta_test.go
+++ b/lib/authenticators/okta/okta_test.go
@@ -149,7 +149,7 @@ func writeStatus(w http.ResponseWriter, status string) {
 
 func TestBaseAPI(t *testing.T) {
 	setupServer()
-	pa, err := NewPublic("somedomain", testlogger.New(t))
+	pa, err := NewPublic("somedomain", "", testlogger.New(t))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This solves the problem when an Okta domain has multiple "subdomains" with
the same username in different subdomains referring to different identities
and hence different passwords.

For example, "fred@domain.com" is unable to log in because
"fred@altdomain.com" was created first and Okta is expecting the password
for "fred@altdomain" when "fred" (@domain.com) attempts to log in.

This collision can happen because:

- A single Okta domain has multiple with "subdomains"

- Keymaster is stripping the `@` and everything afterwards (for internal
  consistency)