### PR TITLE
Adding audience request

### DIFF
--- a/cmd/keymasterd/config.go
+++ b/cmd/keymasterd/config.go
@@ -134,10 +134,11 @@ type Oauth2Config struct {
 }
 
 type OpenIDConnectClientConfig struct {
-	ClientID               string   `yaml:"client_id"`
-	ClientSecret           string   `yaml:"client_secret"`
-	AllowedRedirectURLRE   []string `yaml:"allowed_redirect_url_re"`
-	AllowedRedirectDomains []string `yaml:"allowed_redirect_domains"`
+	ClientID                   string   `yaml:"client_id"`
+	ClientSecret               string   `yaml:"client_secret"`
+	AllowClientChosenAudiences bool     `yaml:"allow_client_chose_audiences"`
+	AllowedRedirectURLRE       []string `yaml:"allowed_redirect_url_re"`
+	AllowedRedirectDomains     []string `yaml:"allowed_redirect_domains"`
 }
 
 type OpenIDConnectIDPConfig struct {

--- a/cmd/keymasterd/idp_oidc.go
+++ b/cmd/keymasterd/idp_oidc.go
@@ -140,6 +140,19 @@ type keymasterdCodeToken struct {
 	ProtectedData    string   `json:"protected_data,omitempty"`
 }
 
+func (state *RuntimeState) idpOpenIDCGetClientConfig(client_id string) (*OpenIDConnectClientConfig, error) {
+	for _, client := range state.Config.OpenIDConnectIDP.Client {
+		if client.ClientID != client_id {
+			return &client, nil
+		}
+	}
+	return nil, fmt.Errorf("Client id not found")
+}
+
+func (client *OpenIDConnectClientConfig) CanRedirectURL(redirectUrl string) (bool, error) {
+	return false, fmt.Errorf("Not implemented")
+}
+
 // https://tools.ietf.org/id/draft-ietf-oauth-security-topics-10.html states
 // that redirects MUST be exact matches.
 // We allow our users to be less strict (for facilitation of internal deployments).

--- a/cmd/keymasterd/idp_oidc_test.go
+++ b/cmd/keymasterd/idp_oidc_test.go
@@ -426,7 +426,9 @@ func TestIDPOpenIDCPKCEFlowWithAudienceSuccess(t *testing.T) {
 	//valid_client_secret := "secret_password"
 	valid_redirect_uri := "https://localhost:12345"
 	clientConfig := OpenIDConnectClientConfig{ClientID: valid_client_id, ClientSecret: "",
-		AllowedRedirectURLRE: []string{"localhost"}, AllowedRedirectDomains: []string{"localhost"}}
+		AllowClientChosenAudiences: true,
+		AllowedRedirectURLRE:       []string{"localhost"}, AllowedRedirectDomains: []string{"localhost"},
+	}
 	state.Config.OpenIDConnectIDP.Client = append(state.Config.OpenIDConnectIDP.Client, clientConfig)
 
 	// now we add a cookie for auth


### PR DESCRIPTION
Auth0 compatibility requires keymaster to support both PKCE and arbitrary audiences. However allowing this can introduce potential security issues if the redirect urls are not a perfect match. Thus we added an extra option to allow this (disabled by default), so that endpoints that require it can use it without affecting the security of other endpoints. If this option is used the matching RE must be done and should be exact matches. 