### PR TITLE
Limit certs to auth lifetime.

### DIFF
--- a/cmd/keymaster/signers.go
+++ b/cmd/keymaster/signers.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"sync"
+)
+
+type signers struct {
+	mutex      sync.RWMutex
+	err        error
+	X509Rsa    *rsa.PrivateKey
+	SshRsa     *rsa.PrivateKey
+	SshEd25519 ed25519.PrivateKey
+}
+
+func makeSigners() *signers {
+	s := signers{}
+	s.mutex.Lock()
+	go s.compute()
+	return &s
+}
+
+func (s *signers) compute() {
+	defer s.mutex.Unlock()
+	x509Signer, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
+	if err != nil {
+		s.err = err
+		return
+	}
+	sshRsaSigner, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
+	if err != nil {
+		s.err = err
+		return
+	}
+	_, sshEd25519Signer, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		s.err = err
+		return
+	}
+	s.X509Rsa = x509Signer
+	s.SshRsa = sshRsaSigner
+	s.SshEd25519 = sshEd25519Signer
+}
+
+// Wait must be called before accessing any of the signers.
+func (s *signers) Wait() error {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.err
+}

--- a/cmd/keymasterd/adminHandlers.go
+++ b/cmd/keymasterd/adminHandlers.go
@@ -28,19 +28,19 @@ func (state *RuntimeState) sendFailureToClientIfNonAdmin(w http.ResponseWriter,
 	// TODO: probably this should be just u2f and AuthTypeKeymasterX509... but
 	// probably we want also to allow configurability for this. Leaving
 	// AuthTypeKeymasterX509 as optional for now
-	authUser, _, err := state.checkAuth(w, r,
+	authData, err := state.checkAuth(w, r,
 		state.getRequiredWebUIAuthLevel()|AuthTypeKeymasterX509)
 	if err != nil {
 		state.logger.Debugf(1, "%v", err)
 		return true, ""
 	}
-	w.(*instrumentedwriter.LoggingWriter).SetUsername(authUser)
-	if !state.IsAdminUser(authUser) {
+	w.(*instrumentedwriter.LoggingWriter).SetUsername(authData.Username)
+	if !state.IsAdminUser(authData.Username) {
 		state.writeFailureResponse(w, r, http.StatusUnauthorized,
 			"Not an admin user")
 		return true, ""
 	}
-	return false, authUser
+	return false, authData.Username
 }
 
 func (state *RuntimeState) ensurePostAndGetUsername(w http.ResponseWriter,

--- a/cmd/keymasterd/app.go
+++ b/cmd/keymasterd/app.go
@@ -1603,40 +1603,60 @@ func main() {
 	serviceMux.HandleFunc(addUserPath, runtimeState.addUserHandler)
 	serviceMux.HandleFunc(deleteUserPath, runtimeState.deleteUserHandler)
 	//TODO: should enable only if bootraptop is enabled
-	serviceMux.HandleFunc(generateBoostrapOTPPath, runtimeState.generateBootstrapOTP)
+	serviceMux.HandleFunc(generateBoostrapOTPPath,
+		runtimeState.generateBootstrapOTP)
 
-	serviceMux.HandleFunc(idpOpenIDCConfigurationDocumentPath, runtimeState.idpOpenIDCDiscoveryHandler)
-	serviceMux.HandleFunc(idpOpenIDCJWKSPath, runtimeState.idpOpenIDCJWKSHandler)
-	serviceMux.HandleFunc(idpOpenIDCAuthorizationPath, runtimeState.idpOpenIDCAuthorizationHandler)
-	serviceMux.HandleFunc(idpOpenIDCTokenPath, runtimeState.idpOpenIDCTokenHandler)
-	serviceMux.HandleFunc(idpOpenIDCUserinfoPath, runtimeState.idpOpenIDCUserinfoHandler)
+	serviceMux.HandleFunc(idpOpenIDCConfigurationDocumentPath,
+		runtimeState.idpOpenIDCDiscoveryHandler)
+	serviceMux.HandleFunc(idpOpenIDCJWKSPath,
+		runtimeState.idpOpenIDCJWKSHandler)
+	serviceMux.HandleFunc(idpOpenIDCAuthorizationPath,
+		runtimeState.idpOpenIDCAuthorizationHandler)
+	serviceMux.HandleFunc(idpOpenIDCTokenPath,
+		runtimeState.idpOpenIDCTokenHandler)
+	serviceMux.HandleFunc(idpOpenIDCUserinfoPath,
+		runtimeState.idpOpenIDCUserinfoHandler)
 
-	staticFilesPath := filepath.Join(runtimeState.Config.Base.SharedDataDirectory, "static_files")
-	serviceMux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir(staticFilesPath))))
-	customWebResourcesPath := filepath.Join(runtimeState.Config.Base.SharedDataDirectory, "customization_data", "web_resources")
+	staticFilesPath :=
+		filepath.Join(runtimeState.Config.Base.SharedDataDirectory,
+			"static_files")
+	serviceMux.Handle("/static/", http.StripPrefix("/static/",
+		http.FileServer(http.Dir(staticFilesPath))))
+	customWebResourcesPath :=
+		filepath.Join(runtimeState.Config.Base.SharedDataDirectory,
+			"customization_data", "web_resources")
 	if _, err = os.Stat(customWebResourcesPath); err == nil {
-		serviceMux.Handle("/custom_static/", http.StripPrefix("/custom_static/", http.FileServer(http.Dir(customWebResourcesPath))))
+		serviceMux.Handle("/custom_static/", http.StripPrefix("/custom_static/",
+			http.FileServer(http.Dir(customWebResourcesPath))))
 	}
-	serviceMux.HandleFunc(u2fRegustisterRequestPath, runtimeState.u2fRegisterRequest)
-	serviceMux.HandleFunc(u2fRegisterRequesponsePath, runtimeState.u2fRegisterResponse)
+	serviceMux.HandleFunc(u2fRegustisterRequestPath,
+		runtimeState.u2fRegisterRequest)
+	serviceMux.HandleFunc(u2fRegisterRequesponsePath,
+		runtimeState.u2fRegisterResponse)
 	serviceMux.HandleFunc(u2fSignRequestPath, runtimeState.u2fSignRequest)
 	serviceMux.HandleFunc(u2fSignResponsePath, runtimeState.u2fSignResponse)
 	serviceMux.HandleFunc(vipAuthPath, runtimeState.VIPAuthHandler)
-	serviceMux.HandleFunc(u2fTokenManagementPath, runtimeState.u2fTokenManagerHandler)
-	serviceMux.HandleFunc(oauth2LoginBeginPath, runtimeState.oauth2DoRedirectoToProviderHandler)
+	serviceMux.HandleFunc(u2fTokenManagementPath,
+		runtimeState.u2fTokenManagerHandler)
+	serviceMux.HandleFunc(oauth2LoginBeginPath,
+		runtimeState.oauth2DoRedirectoToProviderHandler)
 	serviceMux.HandleFunc(redirectPath, runtimeState.oauth2RedirectPathHandler)
-	serviceMux.HandleFunc(clientConfHandlerPath, runtimeState.serveClientConfHandler)
+	serviceMux.HandleFunc(clientConfHandlerPath,
+		runtimeState.serveClientConfHandler)
 	serviceMux.HandleFunc(vipPushStartPath, runtimeState.vipPushStartHandler)
 	serviceMux.HandleFunc(vipPollCheckPath, runtimeState.VIPPollCheckHandler)
 	serviceMux.HandleFunc(totpGeneratNewPath, runtimeState.GenerateNewTOTP)
 	serviceMux.HandleFunc(totpValidateNewPath, runtimeState.validateNewTOTP)
-	serviceMux.HandleFunc(totpTokenManagementPath, runtimeState.totpTokenManagerHandler)
+	serviceMux.HandleFunc(totpTokenManagementPath,
+		runtimeState.totpTokenManagerHandler)
 	serviceMux.HandleFunc(totpVerifyHandlerPath, runtimeState.verifyTOTPHandler)
 	serviceMux.HandleFunc(totpAuthPath, runtimeState.TOTPAuthHandler)
 	if runtimeState.Config.Okta.Domain != "" {
 		serviceMux.HandleFunc(okta2FAauthPath, runtimeState.Okta2FAuthHandler)
-		serviceMux.HandleFunc(oktaPushStartPath, runtimeState.oktaPushStartHandler)
-		serviceMux.HandleFunc(oktaPollCheckPath, runtimeState.oktaPollCheckHandler)
+		serviceMux.HandleFunc(oktaPushStartPath,
+			runtimeState.oktaPushStartHandler)
+		serviceMux.HandleFunc(oktaPollCheckPath,
+			runtimeState.oktaPollCheckHandler)
 	}
 	// TODO(rgooch): Condition this on whether Bootstrap OTP is configured.
 	//               The inline calls to getRequiredWebUIAuthLevel() should be

--- a/cmd/keymasterd/app.go
+++ b/cmd/keymasterd/app.go
@@ -712,7 +712,7 @@ func (state *RuntimeState) getUsernameIfIPRestricted(VerifiedChains [][]*x509.Ce
 		//state.writeFailureResponse(w, r, http.StatusUnauthorized, "revoked Cert")
 		return "", time.Time{}, fmt.Errorf("revoked cert"), nil
 	}
-	return clientName, userCert.NotBefore, nil, nil
+	return clientName, time.Now(), nil, nil
 }
 
 // Inspired by http://stackoverflow.com/questions/21936332/idiomatic-way-of-requiring-http-basic-auth-in-go

--- a/cmd/keymasterd/jwt.go
+++ b/cmd/keymasterd/jwt.go
@@ -80,10 +80,10 @@ func (state *RuntimeState) getAuthInfoFromAuthJWT(serializedToken string) (rvalu
 		err = errors.New("invalid JWT values")
 		return rvalue, err
 	}
-
-	rvalue.Username = inboundJWT.Subject
 	rvalue.AuthType = inboundJWT.AuthType
 	rvalue.ExpiresAt = time.Unix(inboundJWT.Expiration, 0)
+	rvalue.IssuedAt = time.Unix(inboundJWT.IssuedAt, 0)
+	rvalue.Username = inboundJWT.Subject
 	return rvalue, nil
 }
 

--- a/cmd/keymasterd/logFilter.go
+++ b/cmd/keymasterd/logFilter.go
@@ -33,7 +33,7 @@ func (state *RuntimeState) sendFailureToClientIfNotAdminUserOrCA(
 	state.logger.Debugf(4, "request is TLS %+v", r.TLS)
 	if len(r.TLS.VerifiedChains) > 0 {
 		state.logger.Debugf(4, "%+v", r.TLS.VerifiedChains[0][0].Subject)
-		username, err := state.getUsernameIfKeymasterSigned(
+		username, _, err := state.getUsernameIfKeymasterSigned(
 			r.TLS.VerifiedChains)
 		if err != nil {
 			state.logger.Println(err)

--- a/cmd/keymasterd/logFilter.go
+++ b/cmd/keymasterd/logFilter.go
@@ -46,11 +46,11 @@ func (state *RuntimeState) sendFailureToClientIfNotAdminUserOrCA(
 		}
 		return false
 	}
-	username, _, err := state.checkAuth(w, r, state.getRequiredWebUIAuthLevel())
+	authData, err := state.checkAuth(w, r, state.getRequiredWebUIAuthLevel())
 	if err != nil {
 		return true
 	}
-	if !state.IsAdminUser(username) {
+	if !state.IsAdminUser(authData.Username) {
 		http.Error(w, "Not an admin user", http.StatusUnauthorized)
 		return true
 	}

--- a/cmd/keymasterd/main_test.go
+++ b/cmd/keymasterd/main_test.go
@@ -435,7 +435,7 @@ func TestFailSingingExpiredCookie(t *testing.T) {
 	// THis tests needs to be rewritten to have and expired token... need to figure out
 	// the best way to do this.
 	/*
-		state.authCookie[cookieVal] = authInfo{Username: "username", AuthType: AuthTypeU2F, ExpiresAt: time.Now().Add(-120 * time.Second)}
+		state.authCookie[cookieVal] = authInfo{IssuedAt: time.Now(), Username: "username", AuthType: AuthTypeU2F, ExpiresAt: time.Now().Add(-120 * time.Second)}
 		_, err = checkRequestHandlerCode(cookieReq, state.certGenHandler, http.StatusUnauthorized)
 		if err != nil {
 			t.Fatal(err)

--- a/lib/paths/api.go
+++ b/lib/paths/api.go
@@ -1,0 +1,7 @@
+package paths
+
+const (
+	ReceiveAuthDocument = "/receiveAuthDocument"
+	SendAuthDocument    = "/sendAuthDocument"
+	ShowAuthToken       = "/showAuthToken"
+)


### PR DESCRIPTION
Limit certificate lifetimes to the lifetime of the auth_cookie token. Without this change, it's possible to generate certificates up to 48 hours from login thusly:
- perform a login
- receive a 24 hour token
- request a 24 hour certificate
- wait 23.99 hours and request another 24 hour certificate.

Generate keypairs in the background in the `keymaster` CLI tool, while the user is entering their password. This makes the user experience seem faster.

Minor formatting and preparation for Webauth for CLI work.