### PR TITLE
Hide legacy Authenticate and Register buttons.

### DIFF
--- a/cmd/keymasterd/app.go
+++ b/cmd/keymasterd/app.go
@@ -1500,7 +1500,7 @@ func (state *RuntimeState) profileHandler(w http.ResponseWriter, r *http.Request
 		JSSources:            JSSources,
 		ReadOnlyMsg:          readOnlyMsg,
 		UsersLink:            state.IsAdminUser(authData.Username),
-		ShowExperimental:     state.IsAdminUser(authData.Username),
+		ShowLegacyRegister:   state.passwordChecker != nil,
 		RegisteredU2FToken:   u2fdevices,
 		ShowTOTP:             showTOTP,
 		RegisteredTOTPDevice: totpdevices,

--- a/cmd/keymasterd/templateData.go
+++ b/cmd/keymasterd/templateData.go
@@ -309,7 +309,7 @@ type profilePageTemplateData struct {
 	ShowTOTP             bool
 	ReadOnlyMsg          string
 	UsersLink            bool
-	ShowExperimental     bool
+	ShowLegacyRegister   bool
 	RegisteredU2FToken   []registeredU2FTokenDisplayInfo
 	RegisteredTOTPDevice []registeredTOTPTDeviceDisplayInfo
 }
@@ -359,17 +359,16 @@ const profileHTML = `
     <ul>
        {{if .ShowU2F}}
        {{if not .ReadOnlyMsg}}
+       {{if .ShowLegacyRegister}}
       <li>
-         <a id="register_button" href="#">Register token</a>
+         <a id="register_button" href="#">Register token (Legacy)</a>
          <div id="register_action_text" style="color: blue;background-color: yellow; display: none;"> Please Touch the blinking device to register(insert if not inserted yet) </div>
       </li>
       {{end}}
-      <li><a id="auth_button" href="#">Authenticate Legacy</a>
-      <div id="auth_action_text" style="color: blue;background-color: yellow; display: none;"> Please Touch the blinking device to authenticate(insert if not inserted yet) </div>
+      {{end}}
+      <li><a id="webauthn_auth_button" href="#">Authenticate</a>
       </li>
-      <li><a id="webauthn_auth_button" href="#">WebAuthn Authenticate</a>
-      </li>
-      <li><a id="webauthn_register_button" href="#">WebAuthn Register</a>
+      <li><a id="webauthn_register_button" href="#">Register U2F device</a>
       </li>
       {{else}}
       <div id="auth_action_text" style="color: blue;background-color: yellow;"> Your browser does not support U2F. However you can still Enable/Disable/Delete U2F tokens </div>


### PR DESCRIPTION
Hide the legacy Authenticate button. This is no longer needed because all
modern browsers support FIDOv2 and the compatibility code supports
devices registered with FIDOv1.

Hide the legacy Register token button if password login is not enabled.
Sites using only federated login do not need to provide compatibility
for the CLI (which only supports FIDOv1 at the moment), as they redirect
to the Web browser for logins.