### PR TITLE
Release 1.11.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 BINARY=keymaster
 
 # These are the values we want to pass for Version and BuildTime
-VERSION=1.10.3
+VERSION=1.11.0
 #BUILD_TIME=`date +%FT%T%z`
 
 # Setup the -ldflags option for go build here, interpolate the variable values

--- a/keymaster.spec
+++ b/keymaster.spec
@@ -1,5 +1,5 @@
 Name:           keymaster
-Version:        1.10.3
+Version:        1.11.0
 Release:        2%{?dist}
 Summary:        Short term access certificate generator and client
 


### PR DESCRIPTION
Add cache control for static files.
Add global rate limit for password attempts.
Use Origin header in preference to Referer.
Add FIDOv2 protocol support for token registration and web authentication. Refactor AWS role certificate support into a package. Small documentation improvements.
Other bugfixes.