### PR TITLE
Fix: broken jwks url on Ed25519 public keys

### DIFF
--- a/cmd/keymasterd/idp_oidc_test.go
+++ b/cmd/keymasterd/idp_oidc_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/json"
 	stdlog "log"
 	"net/http"
@@ -69,6 +71,18 @@ func TestIDPOpenIDCJWKSHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// now add Ed25519 key to set of public keys
+	_, ed25519Priv, err := ed25519.GenerateKey(rand.Reader)
+	state.KeymasterPublicKeys = append(state.KeymasterPublicKeys, ed25519Priv.Public())
+	req2, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = checkRequestHandlerCode(req2, state.idpOpenIDCJWKSHandler, http.StatusOK)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 }
 
 func TestIDPOpenIDCAuthorizationHandlerSuccess(t *testing.T) {

--- a/keymaster.spec
+++ b/keymaster.spec
@@ -1,5 +1,5 @@
 Name:           keymaster
-Version:        1.13.0
+Version:        1.13.1
 Release:        1%{?dist}
 Summary:        Short term access certificate generator and client
 

--- a/lib/client/aws_role/api.go
+++ b/lib/client/aws_role/api.go
@@ -39,6 +39,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/Cloud-Foundations/golib/pkg/awsutil/presignauth/presigner"
 	"github.com/Cloud-Foundations/golib/pkg/log"
@@ -58,6 +59,7 @@ type Params struct {
 	Signer           crypto.Signer
 	StsClient        *sts.Client
 	StsPresignClient *sts.PresignClient
+	MaxSleepDuration time.Duration
 	derPubKey        []byte
 	isSetup          bool
 	pemPubKey        []byte

--- a/lib/client/aws_role/impl.go
+++ b/lib/client/aws_role/impl.go
@@ -61,6 +61,9 @@ func (m *Manager) refreshOnce() {
 		refreshTime := m.certTLS.Leaf.NotBefore.Add(
 			m.certTLS.Leaf.NotAfter.Sub(m.certTLS.Leaf.NotBefore) * 3 / 4)
 		duration := time.Until(refreshTime)
+		if m.params.MaxSleepDuration > time.Second && duration > m.params.MaxSleepDuration {
+			duration = m.params.MaxSleepDuration
+		}
 		m.params.Logger.Debugf(1, "sleeping: %s before refresh\n",
 			(duration + time.Millisecond*50).Truncate(time.Millisecond*100))
 		time.Sleep(duration)


### PR DESCRIPTION
When the public key set includes ed25519 keys the jwt url was failing because the used library was not able to convert the key to a json value.

This changes libraries and adds tests for ed25519. 
We are still not signing ed25519 JWT.. but this opens the door