### PR TITLE
update makefile, add install-client target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,5 @@ jobs:
       with:
         packages: gcc rpm alien rsync pkg-config libudev-dev
     - uses: actions/checkout@v3
-    - run: make init-config-host
     - run: make rpm
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ BINARY=keymaster
 
 # These are the values we want to pass for Version and BuildTime
 VERSION=1.15.3
+DEFAULT_HOST?=
+DEFAULT_LDFLAGS=-X main.Version=${VERSION}
+CLIENT_LDFLAGS=${DEFAULT_LDFLAGS} -X main.defaultHost=${DEFAULT_HOST}
 #BUILD_TIME=`date +%FT%T%z`
 
 # keymaster client requires special tags on linux
@@ -26,20 +29,22 @@ endif
 # Setup the -ldflags option for go build here, interpolate the variable values
 #LDFLAGS=-ldflags "-X github.com/ariejan/roll/core.Version=${VERSION} -X github.com/ariejan/roll/core.BuildTime=${BUILD_TIME}"
 
-all:	init-config-host cmd/keymasterd/binData.go
-	cd cmd/keymaster; go install ${EXTRA_BUILD_FLAGS} -ldflags "-X main.Version=${VERSION}"
-	cd cmd/keymasterd; go install -ldflags "-X main.Version=${VERSION}"
-	cd cmd/keymaster-unlocker; go install -ldflags "-X main.Version=${VERSION}"
-	cd cmd/keymaster-eventmond;  go install -ldflags "-X main.Version=${VERSION}"
+all:	install-client
+	cd cmd/keymasterd; go install -ldflags "${DEFAULT_LDFLAGS}"
+	cd cmd/keymaster-unlocker; go install -ldflags "${DEFAULT_LDFLAGS}"
+	cd cmd/keymaster-eventmond;  go install -ldflags "${DEFAULT_LDFLAGS}"
 
 build:	cmd/keymasterd/binData.go
-	go build ${EXTRA_BUILD_FLAGS} -ldflags "-X main.Version=${VERSION}" -o bin/   ./...
+	go build ${EXTRA_BUILD_FLAGS} -ldflags "${DEFAULT_LDFLAGS}" -o bin/   ./...
 
 cmd/keymasterd/binData.go:
 	-go-bindata -fs -o cmd/keymasterd/binData.go -prefix cmd/keymasterd/data cmd/keymasterd/data/...
 
+install-client:	init-config-host cmd/keymasterd/binData.go
+	cd cmd/keymaster; go install ${EXTRA_BUILD_FLAGS} -ldflags "${CLIENT_LDFLAGS}"
+
 win-client: client-test
-	 go build -ldflags "-X main.Version=${VERSION}" -o bin .\cmd\keymaster\
+	 go build -ldflags "${CLIENT_LDFLAGS}" -o bin .\cmd\keymaster\
 
 client-test:
 	go test -v  ./cmd/keymaster/...

--- a/cmd/keymaster/main.go
+++ b/cmd/keymaster/main.go
@@ -40,6 +40,7 @@ const (
 
 const userAgentAppName = "keymaster"
 const defaultVersionNumber = "No version provided"
+const defaultConfigHost = ""
 
 var (
 	// Must be a global variable in the data segment so that the build

--- a/cmd/keymaster/main.go
+++ b/cmd/keymaster/main.go
@@ -46,6 +46,7 @@ var (
 	// process can inject the version number on the fly when building the
 	// binary. Use only from the Usage() function.
 	Version         = defaultVersionNumber
+	defaultHost     = defaultConfigHost
 	userAgentString = userAgentAppName
 )
 
@@ -110,10 +111,10 @@ func loadConfigFile(client *http.Client, logger log.Logger) (
 		if err != nil {
 			logger.Fatal(err)
 		}
-	} else if len(defaultConfigHost) > 1 { // if there is a configHost AND there is NO config file, create one
+	} else if len(defaultHost) > 1 { // if there is a configHost AND there is NO config file, create one
 		if _, err := os.Stat(*configFilename); os.IsNotExist(err) {
 			err = config.GetConfigFromHost(
-				*configFilename, defaultConfigHost, client, logger)
+				*configFilename, defaultHost, client, logger)
 			if err != nil {
 				logger.Fatal(err)
 			}

--- a/templates/config_host_go
+++ b/templates/config_host_go
@@ -1,3 +1,0 @@
-package main
-
-const defaultConfigHost = ""


### PR DESCRIPTION
- enables to build client only
- when building with DEFAULT_HOST environment variable set, default hostname is compiled in to the binary (no config file needed)

## Notes
- tested on OSX and Win 2022 server. Build with `make install-client` finished fine, keymaster login successful.

Build with compiled-in default host

```shell
DEFAULT_HOST=https://my-keymaster.server.us make install-client
```