### PR TITLE
enable to specify agent connection to insert cert to

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 BINARY=keymaster
 
 # These are the values we want to pass for Version and BuildTime
-VERSION?=1.15.3
+VERSION?=1.15.4
 DEFAULT_HOST?=
 VERSION_FLAVOUR?=
 EXTRA_LDFLAGS?=

--- a/lib/client/sshagent/api.go
+++ b/lib/client/sshagent/api.go
@@ -2,6 +2,7 @@ package sshagent
 
 import (
 	"golang.org/x/crypto/ssh/agent"
+	"net"
 
 	"github.com/Cloud-Foundations/golib/pkg/log"
 )
@@ -15,6 +16,21 @@ func UpsertCertIntoAgent(
 	return upsertCertIntoAgent(certText, privateKey, comment, lifeTimeSecs, false, logger)
 }
 
+func UpsertCertIntoAgentConnection(
+	certText []byte,
+	privateKey interface{},
+	comment string,
+	lifeTimeSecs uint32,
+	confirmBeforeUse bool,
+	conn net.Conn,
+	logger log.DebugLogger) error {
+	return upsertCertIntoAgentConnection(certText, privateKey, comment, lifeTimeSecs, confirmBeforeUse, conn, logger)
+}
+
 func WithAddedKeyUpsertCertIntoAgent(certToAdd agent.AddedKey, logger log.DebugLogger) error {
 	return withAddedKeyUpsertCertIntoAgent(certToAdd, logger)
+}
+
+func WithAddedKeyUpsertCertIntoAgentConnection(certToAdd agent.AddedKey, conn net.Conn, logger log.DebugLogger) error {
+	return withAddedKeyUpsertCertIntoAgentConnection(certToAdd, conn, logger)
 }


### PR DESCRIPTION
Required for PS to create ephemeral agents to work around limitation on number of auth attempts. For each session we will create a new agent so users can have multiple simultaneous sessions. 