### PR TITLE
client: add support for password via environment variable

### DIFF
--- a/lib/client/util/util.go
+++ b/lib/client/util/util.go
@@ -33,6 +33,11 @@ const rsaKeySize = 2048
 const maxPasswordLength = 512
 
 func getUserCreds(userName string) (password []byte, err error) {
+	// First check for environment variable
+	if envPass := os.Getenv("KEYMASTER_PASSWORD"); envPass != "" {
+		return []byte(envPass), nil
+	}
+
 	fmt.Printf("Password for %s: ", userName)
 
 	if term.IsTerminal(int(os.Stdin.Fd())) {

--- a/lib/client/util/util_test.go
+++ b/lib/client/util/util_test.go
@@ -151,6 +151,22 @@ func TestGetUserCreds(t *testing.T) {
 	}
 }
 
+func TestGetUserCredsFromEnv(t *testing.T) {
+	// Set environment variable
+	const testPassword = "test-password-123"
+	os.Setenv("KEYMASTER_PASSWORD", testPassword)
+	defer os.Unsetenv("KEYMASTER_PASSWORD") // Clean up
+
+	password, err := getUserCreds("username")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(password) != testPassword {
+		t.Errorf("got password %q, want %q", string(password), testPassword)
+	}
+}
+
 // ------------WARN-------- Next name copied from https://github.com/howeyc/gopass/blob/master/pass_test.go for using
 //
 //	gopass checks


### PR DESCRIPTION
Allow setting password through KEYMASTER_PASSWORD environment variable instead of interactive prompt for keymaster CLI.

This pattern aligns with other security tools like Vault CLI (VAULT_TOKEN) and maintains security best practices while enabling automation scenarios.

Hint: This also enables seamless integration with secret management tools like 1password:

Example workflow:
```
$ export KEYMASTER_PASSWORD=$(op read "op://<concealed-vault-name>/<concealed-item-name>/password")
$ keymaster ${KEYMASTER_ARGS} -configHost ${CONFIGHOST} -fileprefix ${CERT}
```

Changes:
- Add environment variable check before password prompt in client util
- Add test coverage for environment variable path
