### PR TITLE
Fix go vet issues with unreachable code

### DIFF
--- a/cmd/keymaster/main.go
+++ b/cmd/keymaster/main.go
@@ -249,9 +249,7 @@ func generateAwsRoleCert(homeDir string,
 		}
 		defer os.Remove(tempPath)
 		return os.Rename(tempPath, x509CertPath)
-
 	}
-	return nil
 }
 
 // Beware, this function has inverted path.... at the beggining

--- a/lib/client/twofa/pushtoken/pushtoken.go
+++ b/lib/client/twofa/pushtoken/pushtoken.go
@@ -254,5 +254,4 @@ func doGenericTokenPushAuthenticate(
 		err := fmt.Errorf("%s timeout", pushType)
 		return err
 	}
-	return nil
 }

--- a/lib/client/twofa/u2f/u2f.go
+++ b/lib/client/twofa/u2f/u2f.go
@@ -413,7 +413,6 @@ func authenticateHelper(req *u2fhost.AuthenticateRequest, devices []*u2fhost.Hid
 			}
 		}
 	}
-	return nil, fmt.Errorf("impossible Error")
 }
 
 // This ensures the hostname matches...at this moment we do NOT check port number

--- a/lib/vip/vip.go
+++ b/lib/vip/vip.go
@@ -418,7 +418,6 @@ func (client *Client) VerifySingleToken(tokenID string, tokenValue int) (bool, e
 	default:
 		return false, nil
 	}
-	panic("should never have reached this point")
 }
 
 func (client *Client) GetActiveTokens(userID string) ([]string, error) {


### PR DESCRIPTION
lib/client/twofa/pushtoken/pushtoken.go:257:2: unreachable code
lib/vip/vip.go:421:2: unreachable code
lib/client/twofa/u2f/u2f.go:416:2: unreachable code
cmd/keymaster/main.go:254:2: unreachable code